### PR TITLE
relax urllib3 constraint to support v2

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -7,7 +7,7 @@ Author-email: sdk@nutanix.com
 Keywords: Nutanix,v4,SDK,Nutanix Virtual Machine Management APIs
 Description-Content-Type: text/markdown
 License-File: LICENSE.txt
-Requires-Dist: urllib3~=1.26
+Requires-Dist: urllib3>=1.26,<3
 Requires-Dist: six~=1.16
 Requires-Dist: certifi>=2020.4.5.1
 Requires-Dist: python-dateutil~=2.8

--- a/ntnx_vmm_py_client.egg-info/PKG-INFO
+++ b/ntnx_vmm_py_client.egg-info/PKG-INFO
@@ -7,7 +7,7 @@ Author-email: sdk@nutanix.com
 Keywords: Nutanix,v4,SDK,Nutanix Virtual Machine Management APIs
 Description-Content-Type: text/markdown
 License-File: LICENSE.txt
-Requires-Dist: urllib3~=1.26
+Requires-Dist: urllib3>=1.26,<3
 Requires-Dist: six~=1.16
 Requires-Dist: certifi>=2020.4.5.1
 Requires-Dist: python-dateutil~=2.8

--- a/ntnx_vmm_py_client.egg-info/requires.txt
+++ b/ntnx_vmm_py_client.egg-info/requires.txt
@@ -1,4 +1,4 @@
-urllib3~=1.26
+urllib3>=1.26,<3
 six~=1.16
 certifi>=2020.4.5.1
 python-dateutil~=2.8

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ VERSION = "4.1.1"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 ~= 1.26", "six ~= 1.16", "certifi >=2020.4.5.1", "python-dateutil ~= 2.8", "pysocks ~= 1.7"]
+REQUIRES = ["urllib3 >=1.26,<3", "six ~= 1.16", "certifi >=2020.4.5.1", "python-dateutil ~= 2.8", "pysocks ~= 1.7"]
 
 package_root_path = os.path.abspath(os.path.dirname(__file__))
 readme_file_path = os.path.join(package_root_path, "README.md")


### PR DESCRIPTION
Changes `urllib3 ~= 1.26` to `>=1.26,<3` in `setup.py` to unblock urllib3 v2.x.

The existing code is fully compatible with urllib3 v2:
- `allowed_methods` is already the v2-correct name (not the removed `method_whitelist`)
- `pool_classes_by_scheme` still exists on `PoolManager` in v2
- All other urllib3 APIs used (`Retry`, `Timeout`, `ProxyManager`, `exceptions.SSLError`) are unchanged in v2

The `<3` upper bound is intentional — it avoids silently pulling in a future urllib3 v3 with its own breaking changes.

Note: there is an existing open PR (#2) from @arpitguptagithub making the same change but with an unbounded `>= 1.26`. This PR uses `>=1.26,<3` to cap at the next major version.